### PR TITLE
Model verifier now can download and unzip before processing.

### DIFF
--- a/utilities/Elite.SpanshTools.Utilities/Elite.SpanshTools.Utilities.csproj
+++ b/utilities/Elite.SpanshTools.Utilities/Elite.SpanshTools.Utilities.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Elite.SpanshTools.csproj" />
   </ItemGroup>
 

--- a/utilities/Elite.SpanshTools.Utilities/Program.cs
+++ b/utilities/Elite.SpanshTools.Utilities/Program.cs
@@ -1,9 +1,21 @@
-﻿using System.Text.Json;
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text.Json;
 using System.Text.Json.Serialization;
+using CommandLine;
 using Elite.SpanshTools.Model;
 
 namespace Elite.SpanshTools.Utilities
 {
+	public class Options
+	{
+		[Option("data-location", Required = true, HelpText = "Existing folder that will hold (or already holds) the data file.")]
+		public string DataLocation { get; set; } = string.Empty;
+
+		[Option("data-file", Required = true, HelpText = "Either an http(s) URI to a zip that contains a single data file, or the name of a file already inside --data-location.")]
+		public string DataFile { get; set; } = string.Empty;
+	}
+
 	public class Program
 	{
 		private readonly static JsonSerializerOptions SerializerOptions = new()
@@ -16,18 +28,137 @@ namespace Elite.SpanshTools.Utilities
 
 		static async Task<int> Main(string[] args)
 		{
-			if (args.Length != 1)
+			var parseResult = Parser.Default.ParseArguments<Options>(args);
+			if (parseResult.Errors.Any())
 			{
-				Console.WriteLine("Usage: ModelVerifier.exe path\\to\\datafile");
 				return 1;
 			}
 
-			if (!File.Exists(args[0]))
+			var options = parseResult.Value;
+
+			string dataLocation;
+			try
 			{
-				Console.WriteLine($"File '{args[0]}' not found.");
+				dataLocation = Path.GetFullPath(options.DataLocation);
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine($"Error: --data-location '{options.DataLocation}' is not a valid path: {e.Message}");
 				return 1;
 			}
 
+			if (!Directory.Exists(dataLocation))
+			{
+				Console.WriteLine($"Error: --data-location '{dataLocation}' does not exist or is not a folder.");
+				return 1;
+			}
+
+			string dataFilePath;
+			if (Uri.TryCreate(options.DataFile, UriKind.Absolute, out var uri)
+				&& (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+			{
+				try
+				{
+					dataFilePath = await DownloadAndExtractAsync(uri, dataLocation);
+				}
+				catch (Exception e)
+				{
+					Console.WriteLine($"Error preparing data file from URI: {e.Message}");
+					return 1;
+				}
+			}
+			else
+			{
+				dataFilePath = Path.GetFullPath(Path.Combine(dataLocation, options.DataFile));
+				if (!File.Exists(dataFilePath))
+				{
+					Console.WriteLine($"File '{dataFilePath}' not found.");
+					return 1;
+				}
+			}
+
+			return await VerifyAsync(dataFilePath);
+		}
+
+		private static async Task<string> DownloadAndExtractAsync(Uri uri, string dataLocation)
+		{
+			var archiveName = Path.GetFileName(uri.LocalPath);
+			if (string.IsNullOrEmpty(archiveName))
+			{
+				throw new InvalidOperationException($"Unable to derive a filename from URI '{uri}'.");
+			}
+
+			if (!archiveName.EndsWith(".gz", StringComparison.OrdinalIgnoreCase))
+			{
+				throw new InvalidOperationException($"Expected a .gz file, but URI '{uri}' points to '{archiveName}'.");
+			}
+
+			var archivePath = Path.GetFullPath(Path.Combine(dataLocation, archiveName));
+			if (File.Exists(archivePath))
+			{
+				File.Delete(archivePath);
+			}
+
+			Console.WriteLine($"Downloading '{uri}' to '{archivePath}'...");
+			var curl = new ProcessStartInfo("curl", ["-L", "-f", "-o", archivePath, uri.ToString()])
+			{
+				RedirectStandardOutput = false,
+				RedirectStandardError = false,
+				UseShellExecute = false
+			};
+
+			using (var process = Process.Start(curl) ?? throw new InvalidOperationException("Failed to start curl."))
+			{
+				await process.WaitForExitAsync();
+				if (process.ExitCode != 0)
+				{
+					throw new InvalidOperationException($"curl exited with code {process.ExitCode}.");
+				}
+			}
+
+			var extractedName = Path.GetFileNameWithoutExtension(archiveName);
+			var extractedPath = Path.GetFullPath(Path.Combine(dataLocation, extractedName));
+			if (File.Exists(extractedPath))
+			{
+				File.Delete(extractedPath);
+			}
+
+			Console.WriteLine($"Extracting '{archivePath}' to '{extractedPath}'...");
+			await using (var source = File.OpenRead(archivePath))
+			await using (var gzip = new GZipStream(source, CompressionMode.Decompress))
+			await using (var destination = File.Create(extractedPath))
+			{
+				var totalCompressed = source.Length;
+				var buffer = new byte[81920];
+				var lastUpdate = DateTime.MinValue;
+				var animationFrames = new[] {'/', '-', '\\', '|'};
+				var curAnimationFrame = 0;
+				int bytesRead;
+				while ((bytesRead = await gzip.ReadAsync(buffer)) > 0)
+				{
+					await destination.WriteAsync(buffer.AsMemory(0, bytesRead));
+
+					var now = DateTime.UtcNow;
+					if ((now - lastUpdate).TotalMilliseconds >= 1000)
+					{
+						var percent = totalCompressed > 0 ? (int)(source.Position * 100L / totalCompressed) : 0;
+						Console.CursorLeft = 0;
+						Console.Write($"Progress: {percent}% {animationFrames[curAnimationFrame % animationFrames.Length]}".PadRight(Console.BufferWidth));
+						curAnimationFrame++;
+						lastUpdate = now;
+					}
+				}
+
+				Console.CursorLeft = 0;
+				Console.WriteLine("Progress: 100%".PadRight(Console.BufferWidth));
+			}
+
+			Console.WriteLine($"Extracted '{extractedPath}'.");
+			return extractedPath;
+		}
+
+		private static async Task<int> VerifyAsync(string dataFilePath)
+		{
 			int recordCount = 0;
 			List<(string Error, string Line)> errors = [];
 
@@ -41,7 +172,7 @@ namespace Elite.SpanshTools.Utilities
 			Console.WriteLine("that takes a long time -- on the order of hours.");
 
 			Console.WriteLine();
-			Console.WriteLine($"Input file: {args[0]}");
+			Console.WriteLine($"Input file: {dataFilePath}");
 			Console.WriteLine("Beginning verificiation process.");
 			Console.WriteLine();
 
@@ -49,7 +180,7 @@ namespace Elite.SpanshTools.Utilities
 			{
 				DateTime start = DateTime.Now;
 				Console.Write("Records parsed: 0");
-				await foreach (var line in File.ReadLinesAsync(args[0]))
+				await foreach (var line in File.ReadLinesAsync(dataFilePath))
 				{
 					if (line == "[" || line == "]")
 					{

--- a/utilities/Elite.SpanshTools.Utilities/Properties/launchSettings.json
+++ b/utilities/Elite.SpanshTools.Utilities/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Elite.SpanshTools.Utilities": {
       "commandName": "Project",
-      "commandLineArgs": "d:\\data\\galaxy.json"
+      "commandLineArgs": "--data-location d:\\data --data-file=https://downloads.spansh.co.uk/galaxy_1day.json.gz"
     }
   }
 }


### PR DESCRIPTION
Added `--data-location` and `--data-file` to model verifier.
* `--data-location` specifies the folder that holds the JSON file for testing the model.
* `--data-file` specifies the JSON file itself.  If this is instead a URI to a gzip (as Spansh provides on his website), the verifier will first download and unzip the file, then use the JSON file inside the archive to test the model.